### PR TITLE
Configurable Ingress

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,0 +1,19 @@
+# Default docker-compose environment file; copy to .env and modify as necessary
+# `docker-compose` must be run in the same directory as this file
+# https://docs.docker.com/compose/environment-variables/#the-env-file
+# environmental variables for interpolation in docker-compose YAML files
+
+
+# https://docs.docker.com/compose/reference/envvars/#compose_project_name
+# Containers started with the below value will have their names prefixed with it
+# Choose something unique to the docker host, eg ${INSTANCE_ID}-dev-${USER}
+COMPOSE_PROJECT_NAME=
+
+# Enable to use static ingress overrides
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.static-ingress.yaml
+
+# Port to expose to internet
+# P_PORT=5000
+
+# Enable to use development overrides
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.yaml

--- a/default.env
+++ b/default.env
@@ -9,8 +9,14 @@
 # Choose something unique to the docker host, eg ${INSTANCE_ID}-dev-${USER}
 COMPOSE_PROJECT_NAME=
 
+# Enable to use dynamic ingress overrides
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.traefik-ingress.yaml
+
 # Enable to use static ingress overrides
 # COMPOSE_FILE=docker-compose.yaml:docker-compose.static-ingress.yaml
+
+# Fully qualified domain name; used to configure ingress
+# SERVER_NAME=foo.cirg.uw.edu
 
 # Port to expose to internet
 # P_PORT=5000

--- a/docker-compose.static-ingress.yaml
+++ b/docker-compose.static-ingress.yaml
@@ -1,0 +1,9 @@
+# docker-compose override to expose web container port (80) to local VM
+# listens on the local VM at http://localhost:${EXTERNAL_PORT}
+---
+version: "3.9"
+services:
+  qr_tabulator:
+    ports:
+      # allow override of published port
+      - 127.0.0.1:${P_PORT:-5000}:5000

--- a/docker-compose.traefik-ingress.yaml
+++ b/docker-compose.traefik-ingress.yaml
@@ -1,0 +1,20 @@
+# docker-compose ingress overrides for traefik
+---
+version: "3.9"
+services:
+  qr_tabulator:
+    labels:
+      - traefik.enable=true
+      # Traefik will route requests with Host matching the SERVER_NAME environment variable (see .env)
+      - traefik.http.routers.qr_tabulator-${COMPOSE_PROJECT_NAME}.rule=Host(`${SERVER_NAME}`)
+
+      - traefik.http.routers.qr_tabulator-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.qr_tabulator-${COMPOSE_PROJECT_NAME}.tls=true
+      - traefik.http.routers.qr_tabulator-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+    networks:
+      - ingress
+networks:
+  # ingress network
+  ingress:
+    name: external_web
+    external: "true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,5 @@ services:
   qr_tabulator:
     build:
       context: .
-    ports:
-      # allow override of published port
-      - 127.0.0.1:${P_PORT:-5000}:5000
     env_file:
       - qr_tabulator.env

--- a/qr_tabulator.env.default
+++ b/qr_tabulator.env.default
@@ -1,5 +1,3 @@
 # default file. copy to gwen.env and modify as necessary
 # Commented variables optional, otherwise required
-SERVER_NAME=
 SECRET_KEY=
-#PREFERRED_URL_SCHEME=

--- a/qr_tabulator/app.py
+++ b/qr_tabulator/app.py
@@ -1,5 +1,4 @@
 from flask import Flask
-from werkzeug.middleware.proxy_fix import ProxyFix
 
 from qr_tabulator.views import base_blueprint
 
@@ -11,7 +10,6 @@ def create_app(testing=False, cli=False):
     app.config["TESTING"] = testing
 
     register_blueprints(app)
-    configure_proxy(app)
 
     return app
 
@@ -19,15 +17,3 @@ def create_app(testing=False, cli=False):
 def register_blueprints(app):
     """register all blueprints for application"""
     app.register_blueprint(base_blueprint)
-
-
-def configure_proxy(app):
-    """Add werkzeug fixer to detect headers applied by upstream reverse proxy"""
-    if app.config.get("PREFERRED_URL_SCHEME", "").lower() == "https":
-        app.wsgi_app = ProxyFix(
-            app=app.wsgi_app,
-            # trust X-Forwarded-Host
-            x_host=1,
-            # trust X-Forwarded-Port
-            x_port=1,
-        )

--- a/qr_tabulator/config.py
+++ b/qr_tabulator/config.py
@@ -4,7 +4,5 @@ Use env var to override
 """
 import os
 
-SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
 # URL scheme to use outside of request context
-PREFERRED_URL_SCHEME = os.getenv("PREFERRED_URL_SCHEME", "http")


### PR DESCRIPTION
- Split ingress configuration into separate docker-compose override files
  - static (eg apache)
  - traefik
- Add default `.env` file

### EDIT

- Remove flask explicit hostname configuration (767b8ab)
  - flask can automatically infer from `X-forward` headers on requests forwarded from traefik